### PR TITLE
Nullpointer if there is no text in inputExpression

### DIFF
--- a/engine/src/main/java/org/camunda/dmn/engine/impl/transform/DmnLiteralExpressionHandler.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/impl/transform/DmnLiteralExpressionHandler.java
@@ -28,9 +28,12 @@ public class DmnLiteralExpressionHandler implements DmnElementHandler<LiteralExp
     if (expressionLanguage != null) {
       dmnExpression.setExpressionLanguage(expressionLanguage.trim());
     }
-    String textContent = expression.getText().getTextContent();
-    if (textContent != null) {
-      dmnExpression.setExpression(textContent.trim());
+    String text = expression.getText();
+    if (text != null) {
+      String textContent = text.getTextContent();
+      if (textContent != null) {
+        dmnExpression.setExpression(textContent.trim());
+      }
     }
     return dmnExpression;
   }


### PR DESCRIPTION
If working with an inputExpression, that misses a text-Tag in Decision-DecisionTable-clause-inputExpression, you get a Nullpointer, because the expression.getText() is null in this case - and ChildElementImpl.getChild(ModelElementInstance element) returns null, if it doesn´t find a childElement

Or am i getting the Schema (http://www.omg.org/spec/DMN/1.0/Beta2/) wrong? But anyway, maybe also other DMN-Users will produce this error and than the error source is not easy to find ;)