### PR TITLE
Fluent API and TestRule improvements

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -38,6 +38,20 @@
       <artifactId>assertj-core</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.12</version>
+      <scope>test</scope>
+    </dependency>
+    
   </dependencies>
 
   <build>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -38,13 +38,7 @@
       <artifactId>assertj-core</artifactId>
       <scope>provided</scope>
     </dependency>
-    
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
-    </dependency>
-    
+        
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/engine/src/main/java/org/camunda/dmn/engine/test/DmnDecisionTest.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/DmnDecisionTest.java
@@ -25,7 +25,7 @@ public abstract class DmnDecisionTest {
   public static final String EXAMPLE_DMN = "org/camunda/dmn/engine/Example.dmn";
 
   @Rule
-  public DmnEngineRule dmnEngineRule = new DmnEngineRule();
+  public DmnEngineRule dmnEngineRule = new DmnEngineRuleBuilder(this).build();
 
   public DmnEngine engine;
   public DmnDecision decision;

--- a/engine/src/main/java/org/camunda/dmn/engine/test/DmnEngineRuleBuilder.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/DmnEngineRuleBuilder.java
@@ -1,0 +1,96 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.dmn.engine.test;
+
+import org.apache.commons.lang3.builder.Builder;
+import org.camunda.dmn.engine.DmnEngineConfiguration;
+import org.camunda.dmn.engine.impl.DmnEngineConfigurationImpl;
+
+public class DmnEngineRuleBuilder implements Builder<DmnEngineRule> {
+
+  private boolean installAssertions;
+  private boolean shutdownAssertions;
+  private DmnEngineConfiguration configuration;
+
+  public DmnEngineRuleBuilder(Object testInstance) {
+    withoutAssertions();
+    fromConfiguration(new DmnEngineConfigurationImpl());
+  }
+
+  /**
+   * Activate installation and shutdown of assertions.
+   * 
+   * @return fluent instance.
+   */
+  public DmnEngineRuleBuilder withAssertions() {
+    this.installAssertions = true;
+    this.shutdownAssertions = true;
+
+    return this;
+  }
+
+  /**
+   * Activate installation and shutdown of assertions.
+   * 
+   * @return fluent instance.
+   */
+  public DmnEngineRuleBuilder withoutAssertions() {
+    this.installAssertions = false;
+    this.shutdownAssertions = false;
+
+    return this;
+  }
+
+  /**
+   * Should install fluent assertions on startup.
+   * 
+   * @param installAssertions
+   *          if true will install.
+   * @return fluent instance.
+   */
+  public DmnEngineRuleBuilder installAssertions(final boolean installAssertions) {
+    this.installAssertions = installAssertions;
+    return this;
+  }
+
+  /**
+   * Should shutdown fluent assertions on shutdown.
+   * 
+   * @param shutdownAssertions
+   *          if true will shutdown.
+   * @return fluent instance.
+   */
+  public DmnEngineRuleBuilder shutdownAssertions(final boolean shutdownAssertions) {
+    this.shutdownAssertions = shutdownAssertions;
+    return this;
+  }
+
+  /**
+   * Create engine using configuration.
+   * 
+   * @param configuration
+   *          configuration to use.
+   * @return fluent instance.
+   */
+  public DmnEngineRuleBuilder fromConfiguration(final DmnEngineConfiguration configuration) {
+    this.configuration = configuration;
+    return this;
+  }
+
+  @Override
+  public DmnEngineRule build() {
+    return new DmnEngineRule(configuration, installAssertions, shutdownAssertions);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/dmn/engine/test/DmnEngineRuleBuilder.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/DmnEngineRuleBuilder.java
@@ -13,11 +13,10 @@
 
 package org.camunda.dmn.engine.test;
 
-import org.apache.commons.lang3.builder.Builder;
 import org.camunda.dmn.engine.DmnEngineConfiguration;
 import org.camunda.dmn.engine.impl.DmnEngineConfigurationImpl;
 
-public class DmnEngineRuleBuilder implements Builder<DmnEngineRule> {
+public class DmnEngineRuleBuilder {
 
   private boolean installAssertions;
   private boolean shutdownAssertions;
@@ -88,7 +87,7 @@ public class DmnEngineRuleBuilder implements Builder<DmnEngineRule> {
     return this;
   }
 
-  @Override
+ 
   public DmnEngineRule build() {
     return new DmnEngineRule(configuration, installAssertions, shutdownAssertions);
   }

--- a/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnAssertions.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnAssertions.java
@@ -20,8 +20,12 @@ import org.camunda.dmn.engine.DmnEngine;
 
 public class DmnAssertions extends Assertions {
 
+  static ThreadLocal<DmnEngineAssertion> dmnDecisionEngineAssertionThreadLocal = new ThreadLocal<DmnEngineAssertion>();
+
   public static DmnEngineAssertion assertThat(DmnEngine engine) {
-    return new DmnEngineAssertion(engine);
+    final DmnEngineAssertion dmnEngineAssertion = new DmnEngineAssertion(engine);
+    DmnAssertions.dmnDecisionEngineAssertionThreadLocal.set(dmnEngineAssertion);
+    return dmnEngineAssertion;
   }
 
   public static DmnDecisionResultAssertion assertThat(DmnDecisionResult result) {
@@ -29,7 +33,17 @@ public class DmnAssertions extends Assertions {
   }
 
   public static DmnDecisionOutputAssertion assertThat(DmnDecisionOutput output) {
-    return new DmnDecisionOutputAssertion(output);
+    DmnDecisionOutputAssertion dmnDecisionOutputAssertion = new DmnDecisionOutputAssertion(output);
+    return dmnDecisionOutputAssertion;
+  }
+
+  public static DmnEngineAssertion decision() {
+    final DmnEngineAssertion dmnEngineAssertion = DmnAssertions.dmnDecisionEngineAssertionThreadLocal.get();
+    return dmnEngineAssertion;
+  }
+
+  public static void reset() {
+    DmnAssertions.dmnDecisionEngineAssertionThreadLocal.remove();
   }
 
 }

--- a/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnDecisionResultAssertion.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnDecisionResultAssertion.java
@@ -31,8 +31,7 @@ public class DmnDecisionResultAssertion extends AbstractAssert<DmnDecisionResult
     if (actualSize != expectedSize) {
       if (expectedSize == 0) {
         failWithMessage("Expected result have no outputs but has <%s>", actualSize);
-      }
-      else {
+      } else {
         failWithMessage("Expected result to have <%s> outputs but has <%s>", expectedSize, actualSize);
       }
     }
@@ -44,7 +43,6 @@ public class DmnDecisionResultAssertion extends AbstractAssert<DmnDecisionResult
     isNotNull();
     return hasSize(0);
   }
-
 
   public DmnDecisionOutputAssertion hasSingleOutput() {
     isNotNull();

--- a/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnEngineAssertion.java
+++ b/engine/src/main/java/org/camunda/dmn/engine/test/asserts/DmnEngineAssertion.java
@@ -83,7 +83,7 @@ public class DmnEngineAssertion extends AbstractAssert<DmnEngineAssertion, DmnEn
     return this;
   }
 
-  public DmnEngineAssertion withContext(String name, Object value, Object... additionalVariablePairs) {
+  public DmnEngineAssertion evaluates(String name, Object value, Object... additionalVariablePairs) {
     isNotNull();
 
     if (additionalVariablePairs.length % 2 != 0) {

--- a/engine/src/test/java/org/camunda/dmn/engine/TestEvaluateDecision.java
+++ b/engine/src/test/java/org/camunda/dmn/engine/TestEvaluateDecision.java
@@ -13,83 +13,68 @@
 
 package org.camunda.dmn.engine;
 
-import static org.camunda.dmn.engine.test.asserts.DmnAssertions.assertThat;
+import static org.camunda.dmn.engine.test.asserts.DmnAssertions.decision;
 
 import org.camunda.dmn.engine.test.DecisionResource;
 import org.camunda.dmn.engine.test.DmnDecisionTest;
+import org.camunda.dmn.engine.test.DmnEngineRule;
+import org.camunda.dmn.engine.test.DmnEngineRuleBuilder;
+import org.junit.Rule;
 import org.junit.Test;
 
-public class TestEvaluateDecision extends DmnDecisionTest {
+public class TestEvaluateDecision {
 
+  @Rule
+  public DmnEngineRule rule = new DmnEngineRuleBuilder(this).withAssertions().build();
+  
   @Test
-  @DecisionResource(resource = NO_INPUT_DMN)
+  @DecisionResource(resource = DmnDecisionTest.NO_INPUT_DMN)
   public void shouldEvaluateRuleWithoutInput() {
-    assertThat(engine)
-      .evaluates(decision)
-      .hasResult("ok");
+    decision().hasResult("ok");
   }
 
   @Test
-  @DecisionResource(resource = ONE_RULE_DMN)
+  @DecisionResource(resource = DmnDecisionTest.ONE_RULE_DMN)
   public void shouldEvaluateSingleRule() {
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext("input", "ok")
+    decision()
+      .evaluates("input", "ok")
       .hasResult("ok");
 
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext("input", "ok")
+    decision()
+      .evaluates("input", "ok")
       .hasResult(null, "ok");
 
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext("input", "notok")
+    decision()
+      .evaluates("input", "notok")
       .hasEmptyResult();
   }
 
   @Test
-  @DecisionResource(resource = EXAMPLE_DMN)
+  @DecisionResource(resource = DmnDecisionTest.EXAMPLE_DMN)
   public void shouldEvaluateExample() {
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext()
-        .setVariable("status", "bronze")
-        .setVariable("sum", 200)
-        .build()
+    decision()
+      .evaluates("status", "bronze", "sum", 200)
       .hasResult()
         .hasSingleOutput()
           .hasEntry("result", "notok")
           .hasEntry("reason", "work on your status first, as bronze you're not going to get anything");
 
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext()
-        .setVariable("status", "silver")
-        .setVariable("sum", 200)
-        .build()
+    decision()
+      .evaluates("status", "silver", "sum", 200)
       .hasResult()
         .hasSingleOutput()
           .hasEntry("result", "ok")
           .hasEntry("reason", "you little fish will get what you want");
 
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext()
-        .setVariable("status", "silver")
-        .setVariable("sum", 1200)
-        .build()
+    decision()
+      .evaluates("status", "silver", "sum", 1200)
       .hasResult()
         .hasSingleOutput()
           .hasEntry("result", "notok")
           .hasEntry("reason", "you took too much man, you took too much!");
 
-    assertThat(engine)
-      .evaluates(decision)
-      .withContext()
-        .setVariable("status", "gold")
-        .setVariable("sum", 200)
-        .build()
+    decision()
+      .evaluates("status", "gold", "sum", 200)
       .hasResult()
         .hasSingleOutput()
           .hasEntry("result", "ok")


### PR DESCRIPTION
Hi guys,

here are some improvements into the direction, which has been described by @berndruecker. I tried to change as little code as possible to allow for needed modifications.

Some general remarks / questions:

- I added commons.lang in order to get a standard builder interface (I believe you use it without it).
- Using ThreadLocal to store the current Engine instance prooved successfully in bpm.assert
- The general test code is more compact
- It could be reasonable to create a getter for the engine inside the `DMNEngineRule`
- Mixing FluentInstance with FluentBuilder seems a little confusing to me (see your withContext method). What is the reason to use the builder pattern here and not to work on the FluentInstance of the `DmnEngineAssertionContext` directly?
- I just added the parameterless `decision()` method, but I believe decision(id) is also an interesting option, if multiple decisions can be parsed from the same decisionResource
- Currently, static assertions is initilized inside of the DmnEngineRule, but it could be a better idea to separate these concerns by creating a `ChainRule` with `DmnEngineRule` as innerRule.
- Before changing your code, I sketched an API of my choice and came to different Assertion classes. My choice was to create fluent classes around `DmnEngine`, `DmnDecision` and `DmnDecisionResult`. (Your choice is `DmnEngine`, `DmnDecisionResult`, `DmnDecisionOutput` and `DmnDecisionOutputEntry`). I believe it is a better choice to implement smarter Conditions working on `DmnDecisionOutput` and `DmnDecisionOutputEntry` and avoid too many fluent assertion classes - you don't need to rebuild the API hierarchy by the fluent instance 1:1.