### PR TITLE
fix(pom): remove imports for embedded dependencies

### DIFF
--- a/feel-juel/pom.xml
+++ b/feel-juel/pom.xml
@@ -104,6 +104,24 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <unpackBundle>false</unpackBundle>
+          <instructions>
+            <Export-Package>
+              ${project.groupId}*
+            </Export-Package>
+            <Import-Package>
+              !de.odysseus.el*,
+              !javax.el,
+              *
+            </Import-Package>
+            <Bundle-ClassPath>.</Bundle-ClassPath>
+            <Embed-Dependency>
+              de.odysseus.el*;inline=true,
+              javax.el*;inline=true
+            </Embed-Dependency>
+          </instructions>
+        </configuration>
         <executions>
           <execution>
             <id>bundle-manifest</id>


### PR DESCRIPTION
change the maven-bundle-plugin instructions so that the embedded
dependencies are not stated as imports