### PR TITLE
Provide API for validating DmnDecisionTable

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTable.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTable.java
@@ -1,0 +1,47 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.dmn.engine;
+
+import java.util.List;
+
+/**
+ * A decision table of the DMN Engine.
+ *
+ * <p>
+ * Specific type of decision that returns {@code true} for {@link #isDecisionTable()}.
+ * </p>
+ */
+public interface DmnDecisionTable extends DmnDecision {
+
+  /**
+   * The declared input columns.
+   *
+   * @return the input, can be empty if not set
+   */
+  List<? extends DmnDecisionTableInput> getInputs();
+
+  /**
+   * The declared output columns.
+   *
+   * @return the outputs, can be empty if not set
+   */
+  List<? extends DmnDecisionTableOutput> getOutputs();
+
+  /**
+   * The declared table rows, i.e. rules.
+   *
+   * @return the rules, can be empty if not set
+   */
+  List<? extends DmnDecisionTableRule> getRules();
+}

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableInput.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableInput.java
@@ -1,0 +1,37 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.dmn.engine;
+
+/**
+ * Single input column definition of a decision table.
+ *
+ * @see DmnDecisionTable
+ */
+public interface DmnDecisionTableInput {
+
+  /**
+   * The human readable name of the input if exists.
+   *
+   * @return the name or null if not set
+   */
+  String getName();
+
+  /**
+   * The expression of the input if exists.
+   *
+   * @return the input expression or null if not set
+   */
+  DmnExpression getExpression();
+
+}

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableOutput.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableOutput.java
@@ -1,0 +1,44 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.dmn.engine;
+
+/**
+ * Single output column definition of a decision table.
+ *
+ * @see DmnDecisionTable
+ */
+public interface DmnDecisionTableOutput {
+
+  /**
+   * The human readable name of the output if exists.
+   *
+   * @return the name or null if not set
+   */
+  String getName();
+
+  /**
+   * The technical name of the output if exists.
+   *
+   * @return the technical name or null if not set
+   */
+  String getOutputName();
+
+  /**
+   * The produced output type's name if exists.
+   *
+   * @return the output type name or null if not set
+   */
+  String getTypeName();
+
+}

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableRule.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionTableRule.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.dmn.engine;
+
+import java.util.List;
+
+/**
+ * Single row definition - i.e. rule - of a decision table.
+ *
+ * @see DmnDecisionTable
+ */
+public interface DmnDecisionTableRule {
+
+  /**
+   * The condition expressions for the respective input columns on a decision table row if exist.
+   *
+   * @return condition cell expressions or null if not set
+   * @see DmnDecisionTable#getInputs()
+   */
+  List<? extends DmnExpression> getConditions();
+
+  /**
+   * The result expressions for the respective output columns on a decision table row if exist.
+   *
+   * @return result cell expressions or null if not set
+   * @see DmnDecisionTable#getOutputs()
+   */
+  List<? extends DmnExpression> getConclusions();
+
+}

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnExpression.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnExpression.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.dmn.engine;
+
+public interface DmnExpression {
+
+  /**
+   * The associated value type's name of the expression if exists.
+   *
+   * @return the type name or null if not set
+   */
+  String getTypeName();
+
+  /**
+   * The expression or script language of the expression if exists.
+   *
+   * @return the language or null if not set
+   */
+  String getExpressionLanguage();
+
+  /**
+   * The actual expression or script if exists.
+   *
+   * @return the expression/script or null if not set
+   * @see #getExpressionLanguage()
+   */
+  String getExpression();
+
+}

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnExpression.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnExpression.java
@@ -13,6 +13,13 @@
 
 package org.camunda.bpm.dmn.engine;
 
+/**
+ * A value expression, in a designated expression or script language, that is part of a decision yielding a single value.
+ *
+ * <p>
+ * The evaluation of an expression can have side effects, if the underlying expression/script alters (part of) the context's data.
+ * </p>
+ */
 public interface DmnExpression {
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableImpl.java
@@ -16,10 +16,10 @@ package org.camunda.bpm.dmn.engine.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.camunda.bpm.dmn.engine.DmnDecision;
+import org.camunda.bpm.dmn.engine.DmnDecisionTable;
 import org.camunda.bpm.dmn.engine.impl.spi.hitpolicy.DmnHitPolicyHandler;
 
-public class DmnDecisionTableImpl implements DmnDecision {
+public class DmnDecisionTableImpl implements DmnDecisionTable {
 
   protected String key;
   protected String name;

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableInputImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableInputImpl.java
@@ -13,7 +13,9 @@
 
 package org.camunda.bpm.dmn.engine.impl;
 
-public class DmnDecisionTableInputImpl {
+import org.camunda.bpm.dmn.engine.DmnDecisionTableInput;
+
+public class DmnDecisionTableInputImpl implements DmnDecisionTableInput {
 
   public static final String DEFAULT_INPUT_VARIABLE_NAME = "cellInput";
 

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableOutputImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableOutputImpl.java
@@ -13,9 +13,10 @@
 
 package org.camunda.bpm.dmn.engine.impl;
 
+import org.camunda.bpm.dmn.engine.DmnDecisionTableOutput;
 import org.camunda.bpm.dmn.engine.impl.spi.type.DmnTypeDefinition;
 
-public class DmnDecisionTableOutputImpl {
+public class DmnDecisionTableOutputImpl implements DmnDecisionTableOutput {
 
   protected String id;
   protected String name;
@@ -52,6 +53,13 @@ public class DmnDecisionTableOutputImpl {
 
   public void setTypeDefinition(DmnTypeDefinition typeDefinition) {
     this.typeDefinition = typeDefinition;
+  }
+
+  public String getTypeName() {
+    if (typeDefinition == null) {
+      return null;
+    }
+    return typeDefinition.getTypeName();
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableRuleImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnDecisionTableRuleImpl.java
@@ -16,7 +16,9 @@ package org.camunda.bpm.dmn.engine.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DmnDecisionTableRuleImpl {
+import org.camunda.bpm.dmn.engine.DmnDecisionTableRule;
+
+public class DmnDecisionTableRuleImpl implements DmnDecisionTableRule {
 
   public String id;
   public String name;

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnExpressionImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DmnExpressionImpl.java
@@ -13,9 +13,10 @@
 
 package org.camunda.bpm.dmn.engine.impl;
 
+import org.camunda.bpm.dmn.engine.DmnExpression;
 import org.camunda.bpm.dmn.engine.impl.spi.type.DmnTypeDefinition;
 
-public class DmnExpressionImpl {
+public class DmnExpressionImpl implements DmnExpression {
 
   protected String id;
   protected String name;
@@ -46,6 +47,13 @@ public class DmnExpressionImpl {
 
   public void setTypeDefinition(DmnTypeDefinition typeDefinition) {
     this.typeDefinition = typeDefinition;
+  }
+
+  public String getTypeName() {
+    if (typeDefinition == null) {
+      return null;
+    }
+    return typeDefinition.getTypeName();
   }
 
   public String getExpressionLanguage() {


### PR DESCRIPTION
This does not change any functionality. I just introduced a few interfaces to avoid having to use the `*Impl` classes.

My **use case**:
* Standalone DMN engine.
* The users can upload DMN decision tables to be evaluated as part of a process.
* I expect certain output columns (identified by their output name and type) to be present.
* I don't want to use the (internal) implementation classes (out of principle).
* The `DmnDecision` interface is not that extensive, i.e. `isDecisionTable()` is not very helpful on its own.

**Solution**:
* Introduction of a `DmnDecisionTable` interface, that exposes the output columns with their output names and types.
* In order to cover potential other use cases as well, the `DmnDecisionTable` interface also exposes the input columns and rule definitions.
* While doing all that, never expose an implementation class, e.g. add `getTypeName()` delegate method to the `DmnExpressionImpl` and `DmnDecisionTableOutputImpl`


I'd be happy about any input/feedback.