### PR TITLE
expose input variable name as variable

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/evaluation/DecisionTableEvaluationHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/evaluation/DecisionTableEvaluationHandler.java
@@ -42,7 +42,6 @@ import org.camunda.bpm.dmn.feel.impl.FeelEngine;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.context.VariableContext;
 import org.camunda.bpm.engine.variable.impl.context.CompositeVariableContext;
-import org.camunda.bpm.engine.variable.impl.context.SingleVariableContext;
 import org.camunda.bpm.engine.variable.value.TypedValue;
 
 public class DecisionTableEvaluationHandler implements DmnDecisionLogicEvaluationHandler {
@@ -164,12 +163,16 @@ public class DecisionTableEvaluationHandler implements DmnDecisionLogicEvaluatio
 
   protected VariableContext getLocalVariableContext(DmnDecisionTableInputImpl input, DmnEvaluatedInput evaluatedInput, VariableContext variableContext) {
     if (isNonEmptyExpression(input.getExpression())) {
+      String inputVariableName = evaluatedInput.getInputVariable();
+
       return CompositeVariableContext.compose(
-        SingleVariableContext.singleVariable(evaluatedInput.getInputVariable(), evaluatedInput.getValue()),
+        Variables.createVariables()
+            .putValueTyped(inputVariableName, evaluatedInput.getValue())
+            .putValue("inputVariableName", inputVariableName)
+            .asVariableContext(),
         variableContext
       );
-    }
-    else {
+    } else {
       return variableContext;
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/evaluation/DecisionTableEvaluationHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/evaluation/DecisionTableEvaluationHandler.java
@@ -167,8 +167,8 @@ public class DecisionTableEvaluationHandler implements DmnDecisionLogicEvaluatio
 
       return CompositeVariableContext.compose(
         Variables.createVariables()
-            .putValueTyped(inputVariableName, evaluatedInput.getValue())
             .putValue("inputVariableName", inputVariableName)
+            .putValueTyped(inputVariableName, evaluatedInput.getValue())
             .asVariableContext(),
         variableContext
       );

--- a/engine/src/test/java/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 public class ExpressionEvaluationTest extends DmnEngineTest {
 
     protected static final String DMN_INPUT_VARIABLE = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.inputVariableName.dmn";
+    protected static final String DMN_OVERRIDE_INPUT_VARIABLE = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.overrideInputVariableName.dmn";
     protected static final String DMN_VARIABLE_CONTEXT = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContext.dmn";
+    protected static final String DMN_VARIABLE_CONTEXT_WITH_INPUT_VARIABLE = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContextWithInputVariable.dmn";
 
     @Test
     @DecisionResource(resource = DMN_INPUT_VARIABLE)
@@ -34,8 +36,24 @@ public class ExpressionEvaluationTest extends DmnEngineTest {
     }
 
     @Test
+    @DecisionResource(resource = DMN_OVERRIDE_INPUT_VARIABLE)
+    public void testOverrideInputVariableName() {
+      DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("in", 2));
+
+      assertThat(decisionResult.getSingleEntry()).isEqualTo(true);
+    }
+
+    @Test
     @DecisionResource(resource = DMN_VARIABLE_CONTEXT)
     public void testHasVariableContext() {
+      DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("in", 3));
+
+      assertThat(decisionResult.getSingleEntry()).isEqualTo(true);
+    }
+
+    @Test
+    @DecisionResource(resource = DMN_VARIABLE_CONTEXT_WITH_INPUT_VARIABLE)
+    public void testHasInputVariableNameInVariableContext() {
       DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("in", 3));
 
       assertThat(decisionResult.getSingleEntry()).isEqualTo(true);

--- a/engine/src/test/java/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.java
@@ -1,0 +1,44 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.dmn.engine.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.dmn.engine.DmnDecisionResult;
+import org.camunda.bpm.dmn.engine.test.DecisionResource;
+import org.camunda.bpm.dmn.engine.test.DmnEngineTest;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.Test;
+
+public class ExpressionEvaluationTest extends DmnEngineTest {
+
+    protected static final String DMN_INPUT_VARIABLE = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.inputVariableName.dmn";
+    protected static final String DMN_VARIABLE_CONTEXT = "org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContext.dmn";
+
+    @Test
+    @DecisionResource(resource = DMN_INPUT_VARIABLE)
+    public void testHasInputVariableName() {
+      DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("in", 2));
+
+      assertThat(decisionResult.getSingleEntry()).isEqualTo(true);
+    }
+
+    @Test
+    @DecisionResource(resource = DMN_VARIABLE_CONTEXT)
+    public void testHasVariableContext() {
+      DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("in", 3));
+
+      assertThat(decisionResult.getSingleEntry()).isEqualTo(true);
+    }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.inputVariableName.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.inputVariableName.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_0afw8ry" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <decisionTable id="decisionTable" hitPolicy="FIRST">
+      <input id="input1" label="in" camunda:inputVariable="foo">
+        <inputExpression id="inputExpression1" typeRef="integer">        <text>in</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="out" name="out" typeRef="boolean" />
+      <rule id="row-914871961-1">
+        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text><![CDATA[${inputVariableName == "foo"}]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0t3v7ny">        <text>true</text>
+</outputEntry>
+      </rule>
+      <rule id="row-914871961-2">
+        <inputEntry id="UnaryTests_03bdgg9">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1htgbok">        <text>false</text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.overrideInputVariableName.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.overrideInputVariableName.dmn
@@ -2,13 +2,13 @@
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_0afw8ry" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
   <decision id="decision" name="Decision">
     <decisionTable id="decisionTable" hitPolicy="FIRST">
-      <input id="input1" label="in" camunda:inputVariable="foo">
+      <input id="input1" label="in" camunda:inputVariable="inputVariableName">
         <inputExpression id="inputExpression1" typeRef="integer">        <text>in</text>
 </inputExpression>
       </input>
       <output id="output1" label="out" name="out" typeRef="boolean" />
       <rule id="row-914871961-1">
-        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text><![CDATA[${inputVariableName == "foo" && foo == 2}]]></text>
+        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text>${inputVariableName == 2}</text>
 </inputEntry>
         <outputEntry id="LiteralExpression_0t3v7ny">        <text>true</text>
 </outputEntry>

--- a/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContext.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContext.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_0afw8ry" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <decisionTable id="decisionTable" hitPolicy="FIRST">
+      <input id="input1" label="in" camunda:inputVariable="foo">
+        <inputExpression id="inputExpression1" typeRef="integer">        <text>in</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="out" name="out" typeRef="boolean" />
+      <rule id="row-914871961-1">
+        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text><![CDATA[${variableContext.resolve('foo').getValue() == 3}]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0t3v7ny">        <text>true</text>
+</outputEntry>
+      </rule>
+      <rule id="row-914871961-2">
+        <inputEntry id="UnaryTests_03bdgg9">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1htgbok">        <text>false</text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContextWithInputVariable.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/dmn/engine/el/ExpressionEvaluationTest.variableContextWithInputVariable.dmn
@@ -8,7 +8,7 @@
       </input>
       <output id="output1" label="out" name="out" typeRef="boolean" />
       <rule id="row-914871961-1">
-        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text><![CDATA[${inputVariableName == "foo" && foo == 2}]]></text>
+        <inputEntry id="UnaryTests_1lhqhwf" expressionLanguage="juel">        <text><![CDATA[${variableContext.resolve('inputVariableName').getValue() == 'foo' && variableContext.resolve('foo').getValue() == 3}]]></text>
 </inputEntry>
         <outputEntry id="LiteralExpression_0t3v7ny">        <text>true</text>
 </outputEntry>


### PR DESCRIPTION
Expose the input variable name of a decision table input as variable itself. This enables an expression / script engine to access the input variable, in case it's not the default variable 'cellInput'.